### PR TITLE
Enable more detailed GC logs including safepoint logging, assign PULSAR_GC

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ bookie_jvm_options: >
  {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_bookie }}" {% endif %}
  PULSAR_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
  PULSAR_GC_LOG=" "
- PULSAR_GC="-Xlog:gc:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+ PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
  PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/bookkeeper"
  
 cust_bookie_jorunal_data_homedirs:

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ pulsar_mem_bookie: "-Xms4g -Xmx4g -XX:MaxDirectMemorySize=4g"
 bookie_jvm_options: >
  {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_bookie }}" {% endif %}
  PULSAR_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
- PULSAR_GC_LOG=" "
- PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
+ PULSAR_GC="-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
+ PULSAR_GC_LOG="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
  PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/bookkeeper"
  
 cust_bookie_jorunal_data_homedirs:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ bookie_jvm_options: >
  {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_bookie }}" {% endif %}
  PULSAR_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
  PULSAR_GC_LOG=" "
- PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+ PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
  PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/bookkeeper"
  
 cust_bookie_jorunal_data_homedirs:

--- a/group_vars/bookkeeper/all
+++ b/group_vars/bookkeeper/all
@@ -42,7 +42,7 @@ bookie_jvm_options: >
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_bookie }}" {% endif %}
   PULSAR_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
   PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/bookkeeper"
 
 # JVM options to run bookie commands
@@ -50,7 +50,7 @@ bookie_jvm_options_b: >
   {% if customize_jvm is defined and customize_jvm|bool %}BOOKIE_MEM="{{ pulsar_mem_bookie }}" {% endif %}
   BOOKIE_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
   BOOKIE_GC_LOG=" "
-  BOOKIE_GC="-Xlog:gc:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  BOOKIE_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
   BOOKIE_LOG_DIR="{{ tgt_pulsar_log_homedir }}/bookkeeper"
 
 #

--- a/group_vars/bookkeeper/all
+++ b/group_vars/bookkeeper/all
@@ -41,8 +41,8 @@ tgt_pulsar_bookie_ledger_data_homedirs: "{% if customize_datadir is defined and 
 bookie_jvm_options: > 
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_bookie }}" {% endif %}
   PULSAR_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
-  PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
+  PULSAR_GC="-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
+  PULSAR_GC_LOG="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/bookkeeper"
 
 # JVM options to run bookie commands

--- a/group_vars/bookkeeper/all
+++ b/group_vars/bookkeeper/all
@@ -42,7 +42,7 @@ bookie_jvm_options: >
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_bookie }}" {% endif %}
   PULSAR_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
   PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/bookkeeper"
 
 # JVM options to run bookie commands
@@ -50,7 +50,7 @@ bookie_jvm_options_b: >
   {% if customize_jvm is defined and customize_jvm|bool %}BOOKIE_MEM="{{ pulsar_mem_bookie }}" {% endif %}
   BOOKIE_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
   BOOKIE_GC_LOG=" "
-  BOOKIE_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  BOOKIE_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
   BOOKIE_LOG_DIR="{{ tgt_pulsar_log_homedir }}/bookkeeper"
 
 #

--- a/group_vars/broker/all
+++ b/group_vars/broker/all
@@ -17,7 +17,7 @@ broker_jvm_options: >
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_broker }}" {% endif %}
   PULSAR_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
   PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/broker"
 
 # whether or not to use customized message replication settings (E/Qw/Qa)

--- a/group_vars/broker/all
+++ b/group_vars/broker/all
@@ -16,8 +16,8 @@ web_svc_port_tls: 8443
 broker_jvm_options: > 
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_broker }}" {% endif %}
   PULSAR_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
-  PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
+  PULSAR_GC="-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
+  PULSAR_GC_LOG="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/broker"
 
 # whether or not to use customized message replication settings (E/Qw/Qa)

--- a/group_vars/broker/all
+++ b/group_vars/broker/all
@@ -17,7 +17,7 @@ broker_jvm_options: >
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_broker }}" {% endif %}
   PULSAR_EXTRA_OPTS="-XX:+PerfDisableSharedMem"
   PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/broker"
 
 # whether or not to use customized message replication settings (E/Qw/Qa)

--- a/group_vars/functions_worker/all
+++ b/group_vars/functions_worker/all
@@ -14,7 +14,7 @@ funcs_worker_jvm_options: >
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_funcs_worker }}" {% endif %}
   PULSAR_EXTRA_OPTS="{{ pulsar_extra_jvm_opts }}"
   PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/functions_worker"
 
 # Function package repilca num

--- a/group_vars/functions_worker/all
+++ b/group_vars/functions_worker/all
@@ -14,7 +14,7 @@ funcs_worker_jvm_options: >
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_funcs_worker }}" {% endif %}
   PULSAR_EXTRA_OPTS="{{ pulsar_extra_jvm_opts }}"
   PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/functions_worker"
 
 # Function package repilca num

--- a/group_vars/functions_worker/all
+++ b/group_vars/functions_worker/all
@@ -13,8 +13,8 @@ funcs_worker_port_tls: 6751
 funcs_worker_jvm_options: > 
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_funcs_worker }}" {% endif %}
   PULSAR_EXTRA_OPTS="{{ pulsar_extra_jvm_opts }}"
-  PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
+  PULSAR_GC="-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
+  PULSAR_GC_LOG="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/functions_worker"
 
 # Function package repilca num

--- a/group_vars/zookeeper/all
+++ b/group_vars/zookeeper/all
@@ -32,5 +32,5 @@ zk_jvm_options: >
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_zk }}"{% endif %}
   PULSAR_EXTRA_OPTS="-Dstats_server_port={{ zk_stats_port }} -XX:+PerfDisableSharedMem"
   PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/zookeeper" 

--- a/group_vars/zookeeper/all
+++ b/group_vars/zookeeper/all
@@ -31,6 +31,6 @@ zk_storage_mnt_path: "{{ tgt_pulsar_zk_data_homedir }}/zookeeper"
 zk_jvm_options: > 
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_zk }}"{% endif %}
   PULSAR_EXTRA_OPTS="-Dstats_server_port={{ zk_stats_port }} -XX:+PerfDisableSharedMem"
-  PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
+  PULSAR_GC="-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
+  PULSAR_GC_LOG="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/zookeeper" 

--- a/group_vars/zookeeper/all
+++ b/group_vars/zookeeper/all
@@ -32,5 +32,5 @@ zk_jvm_options: >
   {% if customize_jvm is defined and customize_jvm|bool %}PULSAR_MEM="{{ pulsar_mem_zk }}"{% endif %}
   PULSAR_EXTRA_OPTS="-Dstats_server_port={{ zk_stats_port }} -XX:+PerfDisableSharedMem"
   PULSAR_GC_LOG=" "
-  PULSAR_GC="-Xlog:gc*,safepoint*:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"
+  PULSAR_GC="-Xlog:gc*,safepoint:{{ tgt_pulsar_gc_log_homedir }}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
   PULSAR_LOG_DIR="{{ tgt_pulsar_log_homedir }}/zookeeper" 


### PR DESCRIPTION
- safepoint logging will reveal how long it takes to reach safepoints.
  more details: https://blanco.io/blog/jvm-safepoint-pauses/

- Java 11 uses a newer syntax to enable safepoint logging with Xlog parameter
  - blog post explaining the syntax of the Xlog parameter:
    https://blog.arkey.fr/2020/07/28/embracing-jvm-unified-logging-jep-158-jep-271/

- remove PULSAR_GC_LOG workaround 

- assign PULSAR_GC to `-XX:+UseG1GC -XX:MaxGCPauseMillis=10`