### PR TITLE
Fix split filter in `pulsar_chkCurVer` role

### DIFF
--- a/roles/pulsar/common/pulsar_chkCurVer/tasks/main.yaml
+++ b/roles/pulsar/common/pulsar_chkCurVer/tasks/main.yaml
@@ -5,7 +5,7 @@
 
 - name: Set existing Pulsar version in a variable  
   set_fact:
-    cur_pulsar_ver: "{{ pulsar_ver_output.stdout_lines[0] | split(':') | last | trim }}"
+    cur_pulsar_ver: "{{ pulsar_ver_output.stdout_lines[0].split(':') | last | trim }}"
 
 - debug: msg="cur_pulsar_ver - {{ cur_pulsar_ver }}"
   when: show_debug_msg|bool


### PR DESCRIPTION
Otherwise the following error manifests
    ```
    fatal: [35.91.69.83]: FAILED! => {"msg": "template error while  templating string: no filter named 'split'. String: {{ pulsar_ver_output.stdout_lines[0] | split(':') | last | trim }}"}
    ```