### PR TITLE
Fix conditional var assignment to avoid failed task when disabled

### DIFF
--- a/01.create_secFiles.yaml
+++ b/01.create_secFiles.yaml
@@ -21,7 +21,7 @@
     jwtTokenOnly: false
     brokerOnly: false
     # srv_host_list: "{{ groups['broker']['private_ip']|join(',') }}"
-    srv_host_list: "{{ groups['broker'] | map('extract', hostvars, ['private_ip']) | join(',') }}"
+    srv_host_list: "{{ groups['broker'] | map('extract', hostvars, ['private_ip']) | join(',') if 'broker' in groups else None }}"
   roles:
     - { role: local_process/gen_secFile/create_jwt_token, 
         user_roles_list: "{{ brkr_super_user_roles_list_str }}",
@@ -56,7 +56,7 @@
     cleanLocalSecStaging: "true"
     showLocalCmdOutput: true
     srv_component: 'functions_worker'
-    srv_host_list: "{{ groups['functions_worker']|join(',') }}"
+    srv_host_list: "{{ groups['functions_worker']|join(',') if 'functions_worker' in groups else None }}"
     jwtTokenOnly: false
     brokerOnly: false
   roles:
@@ -94,7 +94,7 @@
   vars:
     showLocalCmdOutput: true
     srv_component: 'adminConsole'
-    srv_host_list: "{{ groups['adminConsole']|join(',') }}"
+    srv_host_list: "{{ groups['adminConsole']|join(',') if 'adminConsole' in groups else None }}"
     jwtTokenOnly: false
     brokerOnly: false
   roles:

--- a/01.create_secFiles.yaml
+++ b/01.create_secFiles.yaml
@@ -20,8 +20,8 @@
     srv_component: 'broker'
     jwtTokenOnly: false
     brokerOnly: false
-    # srv_host_list: "{{ groups['broker']['private_ip']|join(',') }}"
-    srv_host_list: "{{ groups['broker'] | map('extract', hostvars, ['private_ip']) | join(',') if 'broker' in groups else None }}"
+    # srv_host_list: "{{ groups[srv_component]['private_ip']|join(',') }}"
+    srv_host_list: "{{ groups[srv_component] | map('extract', hostvars, ['private_ip']) | join(',') if srv_component in groups else None }}"
   roles:
     - { role: local_process/gen_secFile/create_jwt_token, 
         user_roles_list: "{{ brkr_super_user_roles_list_str }}",
@@ -56,7 +56,7 @@
     cleanLocalSecStaging: "true"
     showLocalCmdOutput: true
     srv_component: 'functions_worker'
-    srv_host_list: "{{ groups['functions_worker']|join(',') if 'functions_worker' in groups else None }}"
+    srv_host_list: "{{ groups[srv_component]|join(',') if srv_component in groups else None }}"
     jwtTokenOnly: false
     brokerOnly: false
   roles:
@@ -94,7 +94,7 @@
   vars:
     showLocalCmdOutput: true
     srv_component: 'adminConsole'
-    srv_host_list: "{{ groups['adminConsole']|join(',') if 'adminConsole' in groups else None }}"
+    srv_host_list: "{{ groups[srv_component]|join(',') if srv_component in groups else None }}"
     jwtTokenOnly: false
     brokerOnly: false
   roles:


### PR DESCRIPTION
This resolves the following error, that manifests even when disabling pulsarAdmin tls_certs generation for (skip_anco_tls_certs_generatation=true), in the case `groups` doesn't contain `'adminConsole'`.

```
The error was: error while evaluating conditional (srv_host_list!= \"\" and deploy_adminconsole is defined and enable_anco_https is defined and enable_anco_https|bool and skip_anco_tls_certs_generatation is defined and not
skip_anco_tls_certs_generatation|bool): {{ groups['adminConsole']|join(',') }}: 'dict object' has no attribute 'adminConsole'\n\nThe error appears to be in '/opt/evmt-deployments/env_001/pulsar-ansible-master/roles/local_process/gen_secFile/create_tls_certs/tasks/main.yaml'
```
