### PR TITLE
Pass path to pulsar binary to avoid bin not found on control node

### DIFF
--- a/bash/security/authentication/jwt/genUserJwtToken.sh
+++ b/bash/security/authentication/jwt/genUserJwtToken.sh
@@ -7,12 +7,13 @@
 #
 #
 
-
-# Check if "pulsar" executable is available
-whichPulsar=$(which pulsar)
-if [[ "${whichPulsar}" == "" || "${whichPulsar}" == *"not found"* ]]; then
-  echo "Can't find \"pulsar\" executable which is necessary to create JWT tokens"
-  exit 10
+if [[ -z "${whichPulsar}" ]]; then
+    # Check if "pulsar" executable is available
+    whichPulsar=$(which pulsar)
+    if [[ "${whichPulsar}" == "" || "${whichPulsar}" == *"not found"* ]]; then
+        echo "Can't find \"pulsar\" executable which is necessary to create JWT tokens"
+        exit 10
+    fi
 fi
 
 usage() {

--- a/bash/security/authentication/jwt/genUserJwtToken.sh
+++ b/bash/security/authentication/jwt/genUserJwtToken.sh
@@ -1,3 +1,20 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+
 #! /bin/bash
 
 
@@ -14,8 +31,7 @@ if [[ -z "${whichPulsar}" ]]; then
         echo "Can't find \"pulsar\" executable which is necessary to create JWT tokens"
         exit 10
     fi
-fi
-
+fi 
 usage() {
    echo
    echo "Usage: genUserJwtToken.sh [-h] [-r] \

--- a/group_vars/all
+++ b/group_vars/all
@@ -278,3 +278,8 @@ ac_cert_expire_days: 730
 ac_key_password: "MyAncoSrvCertPass"
 
 enable_ac_security: "{{ (enable_brkr_authNZ is defined and enable_brkr_authNZ|bool) or (enable_ac_https is defined and enable_ac_https|bool) }}"
+
+##
+# Ansible controller node specific settings
+#
+pulsar_controller_node_bin: "{{ tgt_pulsar_inst_dir }}/bin/pulsar"    

--- a/roles/local_process/gen_secFile/create_jwt_token/tasks/main.yaml
+++ b/roles/local_process/gen_secFile/create_jwt_token/tasks/main.yaml
@@ -5,6 +5,8 @@
     ./cleanupToken.sh \
       -clst_name {{ cluster_name}} \
       -host_type {{ srv_component }}
+  environment:
+    whichPulsar: "{{ pulsar_controller_node_bin }}"
   when: cleanLocalSecStaging is defined and cleanLocalSecStaging|bool
 - name: ({{ srv_component }}) If authN/authR are enabled, call a bash script to create JWT token files
   shell: |

--- a/roles/local_process/gen_secFile/create_jwt_token/tasks/main.yaml
+++ b/roles/local_process/gen_secFile/create_jwt_token/tasks/main.yaml
@@ -5,8 +5,6 @@
     ./cleanupToken.sh \
       -clst_name {{ cluster_name}} \
       -host_type {{ srv_component }}
-  environment:
-    whichPulsar: "{{ pulsar_controller_node_bin }}"
   when: cleanLocalSecStaging is defined and cleanLocalSecStaging|bool
 - name: ({{ srv_component }}) If authN/authR are enabled, call a bash script to create JWT token files
   shell: |
@@ -15,6 +13,8 @@
       -clst_name {{ cluster_name}} \
       -host_type {{ srv_component }} \
       -user_list {{ user_roles_list }}
+  environment:
+    whichPulsar: "{{ pulsar_controller_node_bin }}"
   register: jwtTokenShell
 - debug: msg="({{ srv_component }}) jwtTokenShell.failed - {{ jwtTokenShell.failed }}"
   when: show_debug_msg|bool and showLocalCmdOutput|bool


### PR DESCRIPTION
Fixes #16 by injecting an environment variable based on the global value of `tgt_pulsar_inst_dir`.