### PR TITLE
Add HeartBeat deployment scripts and files

### DIFF
--- a/11.deploy_heartBeat.yaml
+++ b/11.deploy_heartBeat.yaml
@@ -5,15 +5,35 @@
 ##
 
 #########################
+# PreWork
+# -----------------------
+- hosts: pulsarClient
+  any_errors_fatal: true
+  become: "{{ sudo_needed }}"
+  become_method: sudo
+  roles: 
+    # Set global variables to be used in other tasks/roles
+    - { role: pulsar/common/pulsar_setGlobalVars, varList: 'all' }
+
+#########################
 # HeartBeat Related
 # -----------------------
 - hosts: heartBeat
   become: "{{ sudo_needed }}"
   become_method: sudo
   any_errors_fatal: true
+  gather_facts: true
+  vars:
+    srvStarted: true
+    srv_component: 'heartBeat'
+    srv_ports: ["{{ hb_listen_port }}"]
   roles: 
     - { role: heartbeat/hb_instBinary }
     - { role: heartbeat/hb_config }
-  post_tasks:
-    - name: Start Pulsar HeartBeat
-      shell: cd {{ tgt_heartBeat_inst_dir }}; nohup PULSAR_OPS_MONITOR_CFG=./run_time.yaml {{ heartBeat_bin_name.split('.gz')[0] }} 2>&1 &
+    # Check the current status of the AdminConsole application server
+    - { role: misc/_check_svc_status }
+    # Start the HeartBeat application server
+    - { role: heartbeat/hb_startHbSvc }    
+  #post_tasks:
+  #  - name: Start Pulsar HeartBeat
+  #    shell: cd {{ tgt_heartBeat_inst_dir }}; export PULSAR_OPS_MONITOR_CFG=./runtime.yaml; nohup ./{{ heartBeat_bin_name.split('.gz')[0] }} >/dev/null 2>&1 &

--- a/11.deploy_heartBeat.yaml
+++ b/11.deploy_heartBeat.yaml
@@ -1,20 +1,3 @@
-###
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-###
-
-
 ---
 ##
 ##  NOTE: DO not change the sequence of the tasks!
@@ -51,6 +34,3 @@
     - { role: misc/_check_svc_status }
     # Start the HeartBeat application server
     - { role: heartbeat/hb_startHbSvc }    
-  #post_tasks:
-  #  - name: Start Pulsar HeartBeat
-  #    shell: cd {{ tgt_heartBeat_inst_dir }}; export PULSAR_OPS_MONITOR_CFG=./runtime.yaml; nohup ./{{ heartBeat_bin_name.split('.gz')[0] }} >/dev/null 2>&1 &

--- a/11.deploy_heartBeat.yaml
+++ b/11.deploy_heartBeat.yaml
@@ -1,4 +1,20 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 ---
+
 ##
 ##  NOTE: DO not change the sequence of the tasks!
 ##        Make sure "02.deploy_pulsarCluster.yaml" playbook has been executed beforehand!

--- a/34.shutdown_heartBeat.yaml
+++ b/34.shutdown_heartBeat.yaml
@@ -1,3 +1,18 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 ---
 # Stop and clean up HeartBeat
 - hosts: heartBeat

--- a/34.shutdown_heartBeat.yaml
+++ b/34.shutdown_heartBeat.yaml
@@ -1,0 +1,24 @@
+---
+# Stop and clean up HeartBeat
+- hosts: heartBeat
+  any_errors_fatal: true
+  become: "{{ sudo_needed }}"
+  become_method: sudo
+  vars:
+    srvStarted: true
+    srv_component: 'heartBeat'
+    srv_ports: ["{{ hb_listen_port }}"]
+  roles:
+    # Check the current status of the AdminConsole application server
+    - { role: misc/_check_svc_status }
+    # Stop the AdminConsole application server
+    - { role: heartbeat/hb_stopHbSvc }
+  post_tasks:
+    - name: If requested, clean-up HeartBeat binary and log files
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - "{{ tgt_heartBeat_inst_dir }}"
+        - "{{ tgt_heartBeat_sec_dir }}"
+      when: purge_heartBeat is defined and purge_heartBeat|bool

--- a/35.start_heartBeat.yaml
+++ b/35.start_heartBeat.yaml
@@ -1,3 +1,18 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 ---
 # - Start the HeartBeat server
 - hosts: heartBeat

--- a/35.start_heartBeat.yaml
+++ b/35.start_heartBeat.yaml
@@ -1,0 +1,16 @@
+---
+# - Start the HeartBeat server
+- hosts: heartBeat
+  gather_facts: true
+  any_errors_fatal: true
+  become: "{{ sudo_needed }}"
+  become_method: sudo
+  vars:
+    srvStarted: true
+    srv_component: 'heartBeat'
+    srv_ports: ["{{ hb_listen_port }}"]
+  roles:
+    # Check the current status of the HeartBeat
+    - { role: misc/_check_svc_status }
+    # Start AdminConsole application server
+    - { role: heartbeat/hb_startHbSvc }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   - [4.4. 02.deploy_pulsarCluster.yaml](#44-02deploy_pulsarclusteryaml)
   - [4.5. 03.assign_bookieRackaware.yaml](#45-03assign_bookierackawareyaml)
   - [4.6. 10.deploy_adminConsole.yaml](#46-10deploy_adminconsoleyaml)
-  - [4.7. deploy_heartBeat.yaml](#47-deploy_heartbeatyaml)
+  - [4.7. 11.deploy_heartBeat.yaml](#47-11deploy_heartbeatyaml)
   - [4.8. 20.update_clientSetting.yaml](#48-20update_clientsettingyaml)
   - [4.9. 21.restart_pulsarCluster_with_configChg.yaml](#49-21restart_pulsarcluster_with_configchgyaml)
   - [4.10. 22.update_pulsarCluster_version.yaml](#410-22update_pulsarcluster_versionyaml)
@@ -268,7 +268,7 @@ This playbook is used to deploy DataStax Pulsar AdminConsole [link](https://gith
  
 ## 4.7. 11.deploy_heartBeat.yaml
  
-**TBD** (HeartBeat with security enabled).
+**TBD** (HeartBeat with security enabled is not complete).
  
 This playbook is used to deploy DataStax Pulsar Heartbeat [link](https://github.com/datastax/pulsar-heartbeat), an availability and end-to-end performance tracking tool for a Pulsar cluster.
 
@@ -281,7 +281,7 @@ This playbook does the following tasks:
 
 Note - Output from HeartBeat is redirected to **/dev/null**, no output files are created. Additionally, topic subscription for HeartBeat's consumer is hardcoded to **"latency-measure"**.  Please ensure to create the topics and subscriptions in clusters where auto creation is NOT enabled.
 
-To check the status HeartBeat: Checking for a running process or if Prometheus metrics are enabled in the **all** file, ping the Prometheus port, for example "curl http://hostname:8080/metrics"
+To check the status HeartBeat: Checking for a running process or if Prometheus metrics are enabled in the HeartBeat **all** file, ping the Prometheus port, for example "curl http://hostname:8080/metrics"
 
 The default template configuration file shows examples of parameters for topics, messages size, and test run frequents, and other items.
  

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ When rack-awareness is enabled, this playbook is used to assign bookkeeper nodes
  
 This playbook is used to deploy DataStax Pulsar AdminConsole [link](https://github.com/datastax/pulsar-admin-console), a graphical Web UI for a set of administrative tasks for interacting with a Pulsar cluster.
  
-## 4.7. deploy_heartBeat.yaml
+## 4.7. 11.deploy_heartBeat.yaml
  
 **TBD** (HeartBeat with security enabled).
  
@@ -279,9 +279,11 @@ This playbook does the following tasks:
 3) Uses a default HeartBeat template file, replaces variables as defined in group_vars/heartBeat/all file
 4) Starts the HeartBeat process.
 
-Note - Output from HeartBeat is redirected to /dev/null, so no output files are created.
+Note - Output from HeartBeat is redirected to **/dev/null**, no output files are created. Additionally, topic subscription for HeartBeat's consumer is hardcoded to **"latency-measure"**.  Please ensure to create the topics and subscriptions in clusters where auto creation is NOT enabled.
 
-To check the status HeartBeat: Checking for a running process or if Prometheus metrics are enabled in the **all** file, ping the Prometheus port, for example curl http://hostname:8080/metrics 
+To check the status HeartBeat: Checking for a running process or if Prometheus metrics are enabled in the **all** file, ping the Prometheus port, for example "curl http://hostname:8080/metrics"
+
+The default template configuration file shows examples of parameters for topics, messages size, and test run frequents, and other items.
  
 ## 4.8. 20.update_clientSetting.yaml
  

--- a/group_vars/heartBeat/all
+++ b/group_vars/heartBeat/all
@@ -1,20 +1,3 @@
-###
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-###
-
-
 #
 # Software binary release and version
 # -------------------------------------------
@@ -39,6 +22,10 @@ heartBeat_download_url: "{{ heartBeat_download_url_base }}/{{ heartBeat_ver }}/{
 #
 tgt_pkg_heartBeat_dir: "{{ tgt_pkg_homedir }}/pulsar_heart_beat"
 tgt_heartBeat_inst_dir: /opt/pulsarHeartBeat
+tgt_heartBeat_sec_dir: "{{ tgt_heartBeat_inst_dir }}/security"
 
 # - HeartBeat listending port for Prometheus metrics (DO NOT change it. This is a constant)
 hb_listen_port: 8080
+# Set the GOLANG output temp directory to prevent runtime permission errors in HeartBeat
+# See for env options: https://github.com/google/gops/blob/31f906129ddd78d8be8db50f2e7e8ecc987d7b6d/internal/internal.go#L20
+hb_gops_tempdir: "/tmp/golang"

--- a/group_vars/heartBeat/all
+++ b/group_vars/heartBeat/all
@@ -1,3 +1,18 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 #
 # Software binary release and version
 # -------------------------------------------

--- a/group_vars/heartBeat/all
+++ b/group_vars/heartBeat/all
@@ -22,3 +22,6 @@ heartBeat_download_url: "{{ heartBeat_download_url_base }}/{{ heartBeat_ver }}/{
 #
 tgt_pkg_heartBeat_dir: "{{ tgt_pkg_homedir }}/pulsar_heart_beat"
 tgt_heartBeat_inst_dir: /opt/pulsarHeartBeat
+
+# - HeartBeat listending port for Prometheus metrics (DO NOT change it. This is a constant)
+hb_listen_port: 8080

--- a/group_vars/heartBeat/all
+++ b/group_vars/heartBeat/all
@@ -3,7 +3,7 @@
 # -------------------------------------------
 #
 # - HeartBeat release
-heartBeat_ver: "1.0.13"
+heartBeat_ver: "1.0.14"
 heartBeat_bin_name: "pulsar-heartbeat-{{ heartBeat_ver }}-linux-amd64.gz"
 
 

--- a/roles/heartbeat/hb_config/_base/tasks/main.yaml
+++ b/roles/heartbeat/hb_config/_base/tasks/main.yaml
@@ -1,3 +1,18 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 ---
 - name: Copy Pulsar HeartBeat runtime config (runtime.yaml) template
   template:

--- a/roles/heartbeat/hb_config/_base/tasks/main.yaml
+++ b/roles/heartbeat/hb_config/_base/tasks/main.yaml
@@ -1,0 +1,22 @@
+---
+- name: Copy Pulsar HeartBeat runtime config (runtime.yaml) template
+  template:
+    src: templates/hb_runtime.yaml.tmp
+    dest: "{{ tgt_heartBeat_inst_dir }}/runtime.yaml"
+    owner: "{{ pulsar_user }}"
+    group: "{{ pulsar_user_group }}"
+    mode: "{{ file_permission_mode_noexec }}"
+
+- name: Replace Pulsar HeartBeat config setting placeholders with cluster specific information
+  vars:
+    broker_websvc_url: "{% if enable_brkr_tls is defined and enable_brkr_tls|bool %}https://{{ hostvars[groups['broker'][0]]['webSvcTlsListStr']|trim }}{% else %}http://{{ hostvars[groups['broker'][0]]['webSvcListStr']|trim }}{% endif %}"
+    broker_pulsarvc_url: "{% if enable_brkr_tls is defined and enable_brkr_tls|bool %}pulsar+ssl://{{ hostvars[groups['broker'][0]]['brokerSvcTlsListStr']|trim }}{% else %}pulsar://{{ hostvars[groups['broker'][0]]['brokerSvcListStr']|trim }}{% endif %}"
+  replace:
+       path: "{{ tgt_heartBeat_inst_dir }}/runtime.yaml"
+       regexp: "{{ item.regexp }}"
+       replace: "{{ item.line }}"
+  with_items:
+     - { regexp: '<<home_cluster>>', line: "{{ cluster_name }}" }
+     - { regexp: '<<broker_WebSvc_List_Str>>', line: "{{ broker_websvc_url.split(',')[0] }}" }     
+     - { regexp: '<<broker_Svc_List_Str>>', line: "{{ broker_pulsarvc_url }}" }
+     - { regexp: '<<hb_Listen_Port>>', line: "{{ hb_listen_port }}" }

--- a/roles/heartbeat/hb_config/_security/tasks/main.yaml
+++ b/roles/heartbeat/hb_config/_security/tasks/main.yaml
@@ -1,0 +1,57 @@
+---
+#########################
+# Create broker security related folders for client connection on Pular HeartBeat hosts
+# ------------------------
+- name: If broker authN is enabled, create JWT token related security folders on Pulsar HeartBeat hosts (used for connecting to brokers)
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ pulsar_user }}"
+    group: "{{ pulsar_user_group }}"
+    mode: "{{ file_permission_mode }}"
+  with_items:
+    - "{{ tgt_heartBeat_sec_dir }}/jwt/token"
+  when: enable_brkr_authNZ is defined and enable_brkr_authNZ|bool
+
+- name: If broker TLS is enabled, create TLS certificate related security folders on Pulsar HeartBeat hosts (used for connecting to brokers)
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ pulsar_user }}"
+    group: "{{ pulsar_user_group }}"
+    mode: "{{ file_permission_mode }}"
+  with_items:
+    - "{{ tgt_heartBeat_sec_dir }}/tls/rootca"
+    - "{{ tgt_heartBeat_sec_dir }}/tls/server"
+  when: enable_hb_https is defined and enable_hb_https|bool
+
+
+#########################
+# Copy locally generated security files to Pulsar client hosts
+# ------------------------
+- name: If broker authN is enabled, copy JWT token file to Pulsar HeartBeat host (used for connecting to brokers)
+  copy:
+    src: "{{ item.src_file }}/"
+    dest: "{{ item.dest_file }}"
+    owner: "{{ pulsar_user }}"
+    group: "{{ pulsar_user_group }}"
+  with_items:
+    - { src_file: "{{ local_jwt_src_homedir }}/token/{{ cluster_name }}/brokers/{{ brkr_super_user_roles[0] }}.jwt", 
+        dest_file: "{{ tgt_heartBeat_sec_dir }}/jwt/token/brkr_super_user.jwt" }
+  when: enable_brkr_authNZ is defined and enable_brkr_authNZ|bool
+
+- name: If TLS is enabled, copy the trusted TLS certificate to Pulsar HeartBeat host (used for connecting to brokers)
+  copy:
+    src: "{{ item.src_file }}/"
+    dest: "{{ item.dest_file }}"
+    owner: "{{ pulsar_user }}"
+    group: "{{ pulsar_user_group }}"
+    force: "{{ force_tgt_ac_tls_certs }}"
+  with_items:
+    - { src_file: "{{ local_tls_src_homedir }}/certs/{{ cluster_name }}/{{ srv_component }}s/heartBeat.{{ (hostvars[groups['heartBeat'][0]]['private_ip'])|trim|replace('.','-') }}.key-pk8.pem",
+        dest_file: "{{ hb_https_key_file }}" }
+    - { src_file: "{{ local_tls_src_homedir }}/certs/{{ cluster_name }}/{{ srv_component }}s/heartBeat.{{ (hostvars[groups['heartBeat'][0]]['private_ip'])|trim|replace('.','-') }}.crt.pem",
+        dest_file: "{{ hb_https_cert_file }}" }
+    - { src_file: "{{ local_tls_src_homedir }}/certs/{{ srv_component}}_{{ public_cacert_name }}",
+        dest_file: "{{ hb_https_public_ca_file }}" }
+  when: enable_hb_https is defined and enable_hb_https|bool

--- a/roles/heartbeat/hb_config/_security/tasks/main.yaml
+++ b/roles/heartbeat/hb_config/_security/tasks/main.yaml
@@ -1,3 +1,18 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 ---
 #########################
 # Create broker security related folders for client connection on Pular HeartBeat hosts

--- a/roles/heartbeat/hb_config/tasks/main.yaml
+++ b/roles/heartbeat/hb_config/tasks/main.yaml
@@ -1,20 +1,3 @@
-###
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-###
-
-
 ---
 - name: Copy Pulsar HeartBeat runtime config (runtime.yaml) template
   template:
@@ -34,5 +17,6 @@
        replace: "{{ item.line }}"
   with_items:
      - { regexp: '<<home_cluster>>', line: "{{ cluster_name }}" }
-     - { regexp: '<<broker_WebSvc_List_Str>>', line: "{{ broker_websvc_url }}" }
+     - { regexp: '<<broker_WebSvc_List_Str>>', line: "{{ broker_websvc_url.split(',')[0] }}" }     
      - { regexp: '<<broker_Svc_List_Str>>', line: "{{ broker_pulsarvc_url }}" }
+     - { regexp: '<<hb_Listen_Port>>', line: "{{ hb_listen_port }}" }

--- a/roles/heartbeat/hb_config/tasks/main.yaml
+++ b/roles/heartbeat/hb_config/tasks/main.yaml
@@ -1,3 +1,18 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 ---
 # HeartBeat base configuration (non-security)
 - include_role:

--- a/roles/heartbeat/hb_config/tasks/main.yaml
+++ b/roles/heartbeat/hb_config/tasks/main.yaml
@@ -7,10 +7,15 @@
     group: "{{ pulsar_user_group }}"
     mode: "{{ file_permission_mode_noexec }}"
 
-# - name: Replace Pulsar HeartBeat config setting placeholders with cluster specific information
-#   replace:
-#       path: "{{ tgt_heartBeat_inst_dir }}/runtime.yaml"
-#       regexp: "{{ item.regexp }}"
-#       replace: "{{ item.line }}"
-#   with_items:
-#     - { regexp: '<<home_cluster>>', line: "{{ cluster_name }}" }
+- name: Replace Pulsar HeartBeat config setting placeholders with cluster specific information
+  vars:
+    broker_websvc_url: "{% if enable_brkr_tls is defined and enable_brkr_tls|bool %}https://{{ hostvars[groups['broker'][0]]['webSvcTlsListStr']|trim }}{% else %}http://{{ hostvars[groups['broker'][0]]['webSvcListStr']|trim }}{% endif %}"
+    broker_pulsarvc_url: "{% if enable_brkr_tls is defined and enable_brkr_tls|bool %}pulsar+ssl://{{ hostvars[groups['broker'][0]]['brokerSvcTlsListStr']|trim }}{% else %}pulsar://{{ hostvars[groups['broker'][0]]['brokerSvcListStr']|trim }}{% endif %}"
+  replace:
+       path: "{{ tgt_heartBeat_inst_dir }}/runtime.yaml"
+       regexp: "{{ item.regexp }}"
+       replace: "{{ item.line }}"
+  with_items:
+     - { regexp: '<<home_cluster>>', line: "{{ cluster_name }}" }
+     - { regexp: '<<broker_WebSvc_List_Str>>', line: "{{ broker_websvc_url }}" }
+     - { regexp: '<<broker_Svc_List_Str>>', line: "{{ broker_pulsarvc_url }}" }

--- a/roles/heartbeat/hb_config/tasks/main.yaml
+++ b/roles/heartbeat/hb_config/tasks/main.yaml
@@ -1,22 +1,13 @@
 ---
-- name: Copy Pulsar HeartBeat runtime config (runtime.yaml) template
-  template:
-    src: templates/hb_runtime.yaml.tmp
-    dest: "{{ tgt_heartBeat_inst_dir }}/runtime.yaml"
-    owner: "{{ pulsar_user }}"
-    group: "{{ pulsar_user_group }}"
-    mode: "{{ file_permission_mode_noexec }}"
+# HeartBeat base configuration (non-security)
+- include_role:
+    name: heartbeat/hb_config/_base
 
-- name: Replace Pulsar HeartBeat config setting placeholders with cluster specific information
+# HeartBeat security related configuration
+- include_role:
+    name: heartbeat/hb_config/_security
   vars:
-    broker_websvc_url: "{% if enable_brkr_tls is defined and enable_brkr_tls|bool %}https://{{ hostvars[groups['broker'][0]]['webSvcTlsListStr']|trim }}{% else %}http://{{ hostvars[groups['broker'][0]]['webSvcListStr']|trim }}{% endif %}"
-    broker_pulsarvc_url: "{% if enable_brkr_tls is defined and enable_brkr_tls|bool %}pulsar+ssl://{{ hostvars[groups['broker'][0]]['brokerSvcTlsListStr']|trim }}{% else %}pulsar://{{ hostvars[groups['broker'][0]]['brokerSvcListStr']|trim }}{% endif %}"
-  replace:
-       path: "{{ tgt_heartBeat_inst_dir }}/runtime.yaml"
-       regexp: "{{ item.regexp }}"
-       replace: "{{ item.line }}"
-  with_items:
-     - { regexp: '<<home_cluster>>', line: "{{ cluster_name }}" }
-     - { regexp: '<<broker_WebSvc_List_Str>>', line: "{{ broker_websvc_url.split(',')[0] }}" }     
-     - { regexp: '<<broker_Svc_List_Str>>', line: "{{ broker_pulsarvc_url }}" }
-     - { regexp: '<<hb_Listen_Port>>', line: "{{ hb_listen_port }}" }
+    hb_https_cert_file: "{{ tgt_heartBeat_sec_dir }}/tls/server/heartBeat.{{ (hostvars[groups['heartBeat'][0]]['private_ip'])|trim|replace('.','-') }}.crt.pem"
+    hb_https_key_file: "{{ tgt_heartBeat_sec_dir }}/tls/server/heartBeat.{{ (hostvars[groups['heartBeat'][0]]['private_ip'])|trim|replace('.','-') }}.key-pk8.pem"
+    hb_https_public_ca_file: "{{ tgt_heartBeat_sec_dir }}/tls/rootca/{{ public_cacert_name }}"
+  when: enable_hb_security is defined and enable_hb_security|bool

--- a/roles/heartbeat/hb_startHbSvc/tasks/main.yaml
+++ b/roles/heartbeat/hb_startHbSvc/tasks/main.yaml
@@ -2,8 +2,8 @@
 - name: Start HeartBeat if it is not running yet
   ## NOTE: Do NOT use Ansible "become_user"! Otherwise, ansible will fail to write .async file under /home/{{ pulsar_user }}
   # become_user: "{{ pulsar_user }}"
-  shell: cd {{ tgt_heartBeat_inst_dir }}; export PULSAR_OPS_MONITOR_CFG=./runtime.yaml; nohup ./{{ heartBeat_bin_name.split('.gz')[0] }} >/dev/null 2>&1 &
-#  shell: "cd {{ tgt_adminConsole_inst_dir }}/server/; export NODE_EXTRA_CA_CERTS={% if enable_brkr_tls is defined and enable_brkr_tls|bool %}{{ tgt_adminConsole_sec_dir }}/tls/rootca/{{ public_cacert_name }}{% else %}  {% endif %}; nohup npm start 2>&1 &"
+  # Also, export GOPS_CONFIG_DIR=... is requirement to redirect GOLANG GOPS output 
+  shell: cd {{ tgt_heartBeat_inst_dir }}; {% if sudo_needed|bool %}sudo -u {{ pulsar_user }} {% endif %} -- bash -c 'cd {{ tgt_heartBeat_inst_dir }}; export PULSAR_OPS_MONITOR_CFG=./runtime.yaml; export GOPS_CONFIG_DIR={{ hb_gops_tempdir }}; nohup ./{{ heartBeat_bin_name.split('.gz')[0] }} >/dev/null 2>&1 &'
   # Async shell execution with a very large number
   async: 3153600000 # 100 years
   register: hb_startSvc_cmdcat
@@ -14,7 +14,7 @@
 - name: Wait until HeartBeat is ready
   wait_for:
     host: "{{ private_ip }}"
-    port: "{{ ac_listen_port }}"
+    port: "{{ hb_listen_port }}"
     delay: 2
     timeout: 120
   when: not srvStarted|trim|bool

--- a/roles/heartbeat/hb_startHbSvc/tasks/main.yaml
+++ b/roles/heartbeat/hb_startHbSvc/tasks/main.yaml
@@ -1,0 +1,20 @@
+---
+- name: Start HeartBeat if it is not running yet
+  ## NOTE: Do NOT use Ansible "become_user"! Otherwise, ansible will fail to write .async file under /home/{{ pulsar_user }}
+  # become_user: "{{ pulsar_user }}"
+  shell: cd {{ tgt_heartBeat_inst_dir }}; export PULSAR_OPS_MONITOR_CFG=./runtime.yaml; nohup ./{{ heartBeat_bin_name.split('.gz')[0] }} >/dev/null 2>&1 &
+#  shell: "cd {{ tgt_adminConsole_inst_dir }}/server/; export NODE_EXTRA_CA_CERTS={% if enable_brkr_tls is defined and enable_brkr_tls|bool %}{{ tgt_adminConsole_sec_dir }}/tls/rootca/{{ public_cacert_name }}{% else %}  {% endif %}; nohup npm start 2>&1 &"
+  # Async shell execution with a very large number
+  async: 3153600000 # 100 years
+  register: hb_startSvc_cmdcat
+  when: not srvStarted|trim|bool
+- debug: msg="hb_startSvc_cmdcat.failed - {{ hb_startSvc_cmdcat.failed }}"
+  when: show_debug_msg|bool and not srvStarted|trim|bool
+
+- name: Wait until HeartBeat is ready
+  wait_for:
+    host: "{{ private_ip }}"
+    port: "{{ ac_listen_port }}"
+    delay: 2
+    timeout: 120
+  when: not srvStarted|trim|bool

--- a/roles/heartbeat/hb_startHbSvc/tasks/main.yaml
+++ b/roles/heartbeat/hb_startHbSvc/tasks/main.yaml
@@ -1,3 +1,18 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 ---
 - name: Start HeartBeat if it is not running yet
   ## NOTE: Do NOT use Ansible "become_user"! Otherwise, ansible will fail to write .async file under /home/{{ pulsar_user }}

--- a/roles/heartbeat/hb_stopHbSvc/tasks/main.yaml
+++ b/roles/heartbeat/hb_stopHbSvc/tasks/main.yaml
@@ -1,3 +1,18 @@
+###
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 ---
 - name: Kill the HeartBeat application server process(es)
   include_role:

--- a/roles/heartbeat/hb_stopHbSvc/tasks/main.yaml
+++ b/roles/heartbeat/hb_stopHbSvc/tasks/main.yaml
@@ -1,0 +1,15 @@
+---
+- name: Kill the HeartBeat application server process(es)
+  include_role:
+    role: misc/_kill_svc_pids
+  vars:
+    srv_process_name: "pulsar-heartbeat"
+
+- name: Wait until HeartBeat application server is gone
+  wait_for:
+    host: "{{ private_ip }}"
+    port: "{{ hb_listen_port }}"
+    state: stopped
+    delay: 2
+    timeout: 120
+  when: srvStarted|trim|bool

--- a/templates/hb_runtime.yaml.tmp
+++ b/templates/hb_runtime.yaml.tmp
@@ -10,10 +10,11 @@ prometheusConfig:
   exposeMetrics: true
 slackConfig:
   alertUrl: # required for slack integration to work
-tokenOAuthConfig:
-  ClientID: # "example-client"
-  ClientSecret: # "example-client-secret"
-  TokenURL: # "<token-endpoint of oauth2 provider>"
+# Comment out tokenOAuthConfig is not used, otherwise PH 1.0.14 will not run correctly 
+#tokenOAuthConfig:
+#  ClientID: # "example-client"
+#  ClientSecret: # "example-client-secret"
+#  TokenURL: # "<token-endpoint of oauth2 provider>"
 sitesConfig:
   sites:
 opsGenieConfig:

--- a/templates/hb_runtime.yaml.tmp
+++ b/templates/hb_runtime.yaml.tmp
@@ -1,12 +1,12 @@
 # This is a sample configuration for the Pulsar Heartbeat
 # For all configuration options, see ./src/cfg/config.go
 ---
-name: pbtest # Pulsar cluster name, required
+name: <<home_cluster>> # Pulsar cluster name, required
 tokenFilePath: # path to pulsar jwt, takes precedence over token, if both present
 token: # pulsar jwt
 trustStore: # path to tls truststore
 prometheusConfig:
-  port: ":8080"
+  port: ":<<hb_Listen_Port>>"
   exposeMetrics: true
 slackConfig:
   alertUrl: # required for slack integration to work
@@ -25,8 +25,7 @@ pulsarAdminRestConfig:
   Token: # pulsar jwt, required for pulsarAdminRestConfig to work
   clusters:
   - name: <<home_cluster>>
-#    url: <<broker_WebSvc_List_Str>>
-    url: http://10.166.93.74:8080
+    url: <<broker_WebSvc_List_Str>>
     alertPolicy:
       Ceiling: 10
       MovingWindowSeconds: 30
@@ -43,20 +42,19 @@ pulsarTopicConfig:
       Ceiling: 30
       MovingWindowSeconds: 600
       CeilingInMovingWindow: 5
-  - latencyBudgetMs: 360
-    intervalSeconds: 10
-    pulsarUrl: <<broker_Svc_List_Str>>
+#  - latencyBudgetMs: 360
+#    intervalSeconds: 10
+#    pulsarUrl: <<broker_Svc_List_Str>>
 #    adminUrl: <<broker_WebSvc_List_Str>>
-    adminUrl: http://10.166.93.74:8080
-    topicName: persistent://public/default/reserved-cluster-ptopic
+#    topicName: persistent://public/default/reserved-cluster-ptopic
     #    payloadSizes: ["15B","10B","2B"]
-    payloadSizes: ["5KB"]
-    numberOfMessages: 10
-    numberOfPartitions: 4
-    alertPolicy:
-      Ceiling: 30
-      MovingWindowSeconds: 600
-      CeilingInMovingWindow: 5
+#    payloadSizes: ["5KB"]
+#    numberOfMessages: 10
+#    numberOfPartitions: 4
+#    alertPolicy:
+#      Ceiling: 30
+#      MovingWindowSeconds: 600
+#      CeilingInMovingWindow: 5
 analyticsConfig:
   apiKey:
   ingestionURL:
@@ -67,17 +65,17 @@ k8sConfig:
   pulsarNamespace: default
 brokersConfig:
   intervalSeconds: 15
-  inclusterRestURL: "http://10.166.93.74:8080"
+  inclusterRestURL: <<broker_WebSvc_List_Str>>
   alertPolicy:
     Ceiling: 5
     MovingWindowSeconds: 600
     CeilingInMovingWindow: 8
-webSocketConfig:
-  - latencyBudgetMs: 640
-    name: pbtest
-    intervalSeconds: 60
-    cluster: pbtest
-    topicName: persistent/public/default/test-topic234
-    scheme: "wss://"
-    port: "8500"
-    urlQueryParams: "token="
+#webSocketConfig:
+#  - latencyBudgetMs: 640
+#    name: <<home_cluster>>WebSocket
+#    intervalSeconds: 60
+#    cluster: <<home_cluster>>
+#    topicName: persistent/public/default/test-topic234
+#    scheme: "wss://"
+#    port: "8500"
+#    urlQueryParams: "token="

--- a/templates/hb_runtime.yaml.tmp
+++ b/templates/hb_runtime.yaml.tmp
@@ -1,0 +1,83 @@
+# This is a sample configuration for the Pulsar Heartbeat
+# For all configuration options, see ./src/cfg/config.go
+---
+name: pbtest # Pulsar cluster name, required
+tokenFilePath: # path to pulsar jwt, takes precedence over token, if both present
+token: # pulsar jwt
+trustStore: # path to tls truststore
+prometheusConfig:
+  port: ":8080"
+  exposeMetrics: true
+slackConfig:
+  alertUrl: # required for slack integration to work
+tokenOAuthConfig:
+  ClientID: # "example-client"
+  ClientSecret: # "example-client-secret"
+  TokenURL: # "<token-endpoint of oauth2 provider>"
+sitesConfig:
+  sites:
+opsGenieConfig:
+  intervalSeconds: 180
+  heartbeatKey: # GenieKey key for heartbeat
+  alertKey: # GenieKey api key to generate alerts or incidents
+pulsarAdminRestConfig:
+  intervalSeconds: 120
+  Token: # pulsar jwt, required for pulsarAdminRestConfig to work
+  clusters:
+  - name: <<home_cluster>>
+#    url: <<broker_WebSvc_List_Str>>
+    url: http://10.166.93.74:8080
+    alertPolicy:
+      Ceiling: 10
+      MovingWindowSeconds: 30
+      CeilingInMovingWindow: 10
+pulsarTopicConfig:
+  - latencyBudgetMs: 360
+    intervalSeconds: 30
+    pulsarUrl: <<broker_Svc_List_Str>>
+    topicName: persistent://public/default/reserved-cluster-monitoring
+    #    payloadSizes: ["15B","10B","2B"]
+    payloadSizes: ["115KB"]
+    numberOfMessages: 10
+    alertPolicy:
+      Ceiling: 30
+      MovingWindowSeconds: 600
+      CeilingInMovingWindow: 5
+  - latencyBudgetMs: 360
+    intervalSeconds: 10
+    pulsarUrl: <<broker_Svc_List_Str>>
+#    adminUrl: <<broker_WebSvc_List_Str>>
+    adminUrl: http://10.166.93.74:8080
+    topicName: persistent://public/default/reserved-cluster-ptopic
+    #    payloadSizes: ["15B","10B","2B"]
+    payloadSizes: ["5KB"]
+    numberOfMessages: 10
+    numberOfPartitions: 4
+    alertPolicy:
+      Ceiling: 30
+      MovingWindowSeconds: 600
+      CeilingInMovingWindow: 5
+analyticsConfig:
+  apiKey:
+  ingestionURL:
+  insightsWriteKey:
+  insightsAccountId: ""
+k8sConfig:
+  enabled: false
+  pulsarNamespace: default
+brokersConfig:
+  intervalSeconds: 15
+  inclusterRestURL: "http://10.166.93.74:8080"
+  alertPolicy:
+    Ceiling: 5
+    MovingWindowSeconds: 600
+    CeilingInMovingWindow: 8
+webSocketConfig:
+  - latencyBudgetMs: 640
+    name: pbtest
+    intervalSeconds: 60
+    cluster: pbtest
+    topicName: persistent/public/default/test-topic234
+    scheme: "wss://"
+    port: "8500"
+    urlQueryParams: "token="


### PR DESCRIPTION
Add Pulsar HeartBeat Ansible scripts and related files to allow for deployment on VMs. README updated with instructions.  NOTE - this PR does not include deployment of HeartBeat with security enabled.  That is not complete and TBD.