### PR TITLE
Add support to install requirements on RHEL controlled nodes

### DIFF
--- a/roles/misc/_inst_openjdk/tasks/main.yaml
+++ b/roles/misc/_inst_openjdk/tasks/main.yaml
@@ -16,8 +16,14 @@
 
 
 ---
+- name: Print ansible_distribution fact on managed hosts
+  debug:
+    msg: Managed hosts running on {{ ansible_facts['distribution'] }}
+  tags:
+    - jdk_install
+    
 # Ubuntu/APT installation
-- name: Install OpenJDK Java
+- name: Install Python and OpenJDK Java on Ubuntu
   apt:
     name: "{{ item }}"
     state: present
@@ -25,3 +31,18 @@
   with_items:
     - python-apt
     - openjdk-{{ openjdk_ver }}-jdk
+  tags:
+    - jdk_install
+  when: ansible_facts['distribution'] == "Ubuntu"
+    
+# RedHat/DNF installation
+- name: Install Python 3.8 and OpenJDK Java on RedHat
+  dnf:
+    name:
+      - python38
+      - java-{{ openjdk_ver }}-openjdk
+    state: present
+    update_cache: yes
+  tags:
+    - jdk_install
+  when: ansible_facts['distribution'] == "RedHat"


### PR DESCRIPTION
Solves #27.

I preferred using the `dnf` ansible module rather than the generic `package` module, as it's always better being more specific whenever possible, when deciding on modules. This is a best practice given by [Sander van Vugt](https://www.pearsonitcertification.com/authors/bio/4b5219b6-d4c0-4ebd-866c-c2132adbc744) in [a O'Really video
course](https://learning.oreilly.com/videos/ansible-from-basics/9780137894949/). I would assume this is mainly due to compatibility problems there might be under-the-hood when using generic modules.